### PR TITLE
Handle non-fully-active Documents better

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -200,6 +200,7 @@ Each {{CloseWatcher}} has an <dfn for="CloseWatcher">is active</dfn>, which is a
 <div algorithm>
   The <dfn constructor for="CloseWatcher" lt="CloseWatcher()">new CloseWatcher()</dfn> constructor steps are:
 
+  1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=], then throw an "{{InvalidStateError}}" {{DOMException}}.
   1. If we [=cannot create a developer-controlled close watcher=] for [=this=]'s [=relevant global object=]'s [=associated document=], then throw a "{{NotAllowedError}}" {{DOMException}}.
   1. Set [=this=]'s [=CloseWatcher/is active=] to true.
   1. [=stack/Push=] a new [=close watcher=] on [=this=]'s [=relevant global object=]'s [=associated document=]'s [=close watcher stack=], with its [=struct/items=] set as follows:
@@ -224,11 +225,11 @@ Objects implementing the {{CloseWatcher}} interface must support the <dfn attrib
 
   1. If |closeWatcher|'s [=CloseWatcher/is active=] is false, then return.
   1. Let |window| be |closeWatcher|'s [=relevant global object=].
-  1. If |window|'s [=timestamp of last activation used for close watchers=] does not equal |window|'s <a spec="HTML">last activation timestamp</a>, then:
+  1. If |window|'s [=associated Document=] is [=Document/fully active=], and |window|'s [=timestamp of last activation used for close watchers=] does not equal |window|'s <a spec="HTML">last activation timestamp</a>, then:
     1. Let |shouldContinue| be the result of [=firing an event=] named {{CloseWatcher/cancel}} at |closeWatcher|, with the {{Event/cancelable}} attribute initialized to true.
     1. Set |window|'s [=timestamp of last activation used for close watchers=] to |window|'s <a spec="HTML">last activation timestamp</a>.
     1. If |shouldContinue| is false, then return.
-  1. [=Fire an event=] named {{CloseWatcher/close}} at |closeWatcher|.
+  1. If |window|'s [=associated Document=] is [=Document/fully active=], then [=fire an event=] named {{CloseWatcher/close}} at |closeWatcher|.
   1. Set |closeWatcher|'s [=CloseWatcher/is active=] to false.
 </div>
 


### PR DESCRIPTION
Do not fire any events, and don't allow new CloseWatcher().


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/close-watcher/pull/6.html" title="Last updated on Sep 20, 2021, 7:55 PM UTC (791fdd6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/close-watcher/6/e39bb0a...791fdd6.html" title="Last updated on Sep 20, 2021, 7:55 PM UTC (791fdd6)">Diff</a>