### PR TITLE
Remove check for the open attribute before closing dialog

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -282,9 +282,7 @@ Replace the "Canceling dialogs" section entirely with the following definition. 
     1. Set |window|'s [=timestamp of last activation used for close watchers=] to |window|'s <a spec="HTML">last activation timestamp</a>.
     1. If |shouldContinue| is false, then return.
 
-  1. If |dialog| has an <{dialog/open}> content attribute, then <a spec="HTML" lt="close">close the dialog</a> |dialog| with no return value.
-
-     <p class="note">We need to check for the attribute since any {{HTMLElement/cancel}} event handlers might have removed it.
+  1. <a spec="HTML" lt="close">Close the dialog</a> |dialog| with no return value.
 </div>
 
 <h2 id="security-and-privacy">Security and privacy considerations</h2>


### PR DESCRIPTION
The dialog closing steps already check for the open attribute before
continuing, so I think this check is redundant:
https://html.spec.whatwg.org/multipage/interactive-elements.html#close-the-dialog

I noticed this redudant check while implementing the dialog integration.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/josepharhar/close-watcher/pull/12.html" title="Last updated on Mar 3, 2022, 10:58 PM UTC (d73aaba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/close-watcher/12/9e1c541...josepharhar:d73aaba.html" title="Last updated on Mar 3, 2022, 10:58 PM UTC (d73aaba)">Diff</a>