### PR TITLE
Fix link to spec.bs commits

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -12,7 +12,7 @@ Metadata Include: This version off
 Editor: Domenic Denicola, Google https://www.google.com/, d@domenic.me, https://domenic.me/
 Abstract: The close watcher API provides a platform-agnostic way of handling close signals.
 !Participate: <a href="https://github.com/WICG/close-watcher">GitHub WICG/close-watcher</a> (<a href="https://github.com/WICG/close-watcher/issues/new">new issue</a>, <a href="https://github.com/WICG/close-watcher/issues?state=open">open issues</a>)
-!Commits: <a href="https://github.com/WICG/close-watcher/commits/master/spec.bs">GitHub spec.bs commits</a>
+!Commits: <a href="https://github.com/WICG/close-watcher/commits/main/spec.bs">GitHub spec.bs commits</a>
 Complain About: accidental-2119 yes, missing-example-ids yes
 Indent: 2
 Default Biblio Status: current


### PR DESCRIPTION
It still points to the master branch which got renamed main


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/close-watcher/pull/27.html" title="Last updated on Apr 14, 2023, 4:59 PM UTC (b97205a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/close-watcher/27/3a18e68...lukewarlow:b97205a.html" title="Last updated on Apr 14, 2023, 4:59 PM UTC (b97205a)">Diff</a>